### PR TITLE
Remove server binary polluting the global $PATH

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,8 +1,0 @@
-#!/usr/bin/env node
-var path = require('path');
-
-require('babel-register')({
-  "presets": ["es2015"]
-});
-require('app-module-path').addPath(path.join(__dirname, '../src'));
-require('server/dev'); 


### PR DESCRIPTION
The `server` binary looks like it should be a sub-command, as at the moment we run the risk of it clashing with another global `server` command. This PR removes it with the intention of it being replaced by `blackjack preview`.