### PR TITLE
Implement init command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",
+    "colors": "^1.1.2",
     "commander": "^2.9.0",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",
+    "change-case": "^2.3.1",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "eslint": "^2.4.0",
@@ -34,14 +35,12 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "install": "^0.6.1",
     "jasmine-core": "^2.4.1",
+    "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",
     "nexpect": "^0.5.0",
     "phantomjs-prebuilt": "^2.1.7",
     "react": "^0.14.7",
     "react-inlinesvg": "^0.4.2",
     "webpack": "^1.12.14"
-  },
-  "devDependencies": {
-    "jasmine-core": "^2.4.1"
   }
 }

--- a/src/application.js
+++ b/src/application.js
@@ -18,9 +18,12 @@ export function run() {
     description('Creates a production bundle of CSS/JS.').
     action(executeCommand);
 
-  commander.command('init').
-    description('Create a new component.').
-    action(executeCommand);
+  commander.command('init <name>').
+    description('Create a new component project from called [name].').
+    action((name, options) => {
+      options.name = name;
+      executeCommand(options);
+    });
 
   commander.command('lint').
     description('Lint all in test and lib dirs.').

--- a/src/application.js
+++ b/src/application.js
@@ -1,5 +1,6 @@
 import commander from 'commander';
 import info from '../package.json';
+import logger from './util/logger';
 
 export function run() {
   commander.version(info.version);
@@ -8,7 +9,7 @@ export function run() {
     const name = options._name;
     const command = require(`./commands/${name}`);
 
-    console.log(`Running '${name}' command...\n`);
+    logger.info(`Running '${name}' command...\n`);
 
     command.call(options);
   }

--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -1,3 +1,5 @@
+import logger from '../util/logger';
+
 export function call() {
-  console.log('This is a stub for the bundle command, it is not yet implemented.');
+  logger.warn('This is a stub for the bundle command, it is not yet implemented.');
 }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,3 +1,26 @@
-export function call() {
-  console.log('This is a stub for the init command, it is not yet implemented.');
+import caseChanger from 'change-case';
+import logger from '../util/logger';
+import { WORKING_DIR } from '../constants';
+
+import DirectoryCreator from '../project-creation/directory-creator';
+import ComponentCreator from '../project-creation/component-creator';
+import StylesCreator from '../project-creation/styles-creator';
+import TestCreator from '../project-creation/test-creator';
+import GitignoreCreator from '../project-creation/gitignore-creator';
+import PackageCreator from '../project-creation/package-creator';
+import ReadmeCreator from '../project-creation/readme-creator';
+
+export function call(options) {
+  const name = caseChanger.paramCase(options.name);
+  const workingDir = `${WORKING_DIR}/${name}`;
+
+  DirectoryCreator.run(workingDir);       // name/
+  ComponentCreator.run(workingDir, name); // name/src/components/name.js
+  StylesCreator.run(workingDir, name);    // name/styles/_name.scss
+  TestCreator.run(workingDir, name);      // name/tests/components/name.test.js
+  GitignoreCreator.run(workingDir, name); // name/.gitignore
+  PackageCreator.run(workingDir, name);   // name/package.json
+  ReadmeCreator.run(workingDir, name);    // name/README.md
+
+  logger.info('\nProject setup 👊');
 }

--- a/src/commands/preview.js
+++ b/src/commands/preview.js
@@ -1,3 +1,5 @@
+import logger from '../util/logger';
+
 export function call() {
-  console.log('This is a stub for the preview command, it is not yet implemented.');
+  logger.warn('This is a stub for the preview command, it is not yet implemented.');
 }

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -1,4 +1,5 @@
 import exec from '../util/exec';
+import logger from '../util/logger';
 import {
   MOCHA_BIN,
   TEST_GLOB,
@@ -21,7 +22,7 @@ export function call(options) {
     break;
 
     default:
-      console.warn('Test runner unsupported!');
+      logger.warn(`Test runner '${runner}' unsupported!`);
     break;
 
   }

--- a/src/project-creation/component-creator.js
+++ b/src/project-creation/component-creator.js
@@ -1,0 +1,37 @@
+import caseChanger from 'change-case';
+import logger from '../util/logger';
+import DirectoryCreator from './directory-creator';
+import FileCreator from './file-creator';
+
+export default {
+
+  buildTemplate(name){
+    const klass = caseChanger.pascalCase(name);
+
+    return `import React from 'react';
+
+class ${klass} extends React.Component {
+
+  render(){
+    return 'Hello world!';
+  }
+
+}
+
+export default ${klass};
+`;
+  },
+
+  run(directoryPath, name) {
+    const directory = `${directoryPath}/src/components`;
+    const underscoreName = caseChanger.snakeCase(name);
+    const template = this.buildTemplate(name)
+    const path = `${directory}/${underscoreName}.js`;
+
+    DirectoryCreator.run(directory)
+    FileCreator.run(path, template);
+
+    logger.success(`+ ${path}`);
+  }
+
+}

--- a/src/project-creation/directory-creator.js
+++ b/src/project-creation/directory-creator.js
@@ -1,0 +1,15 @@
+import mkdir from 'mkdirp';
+import logger from '../util/logger';
+
+export default {
+
+  run(directoryPath) {
+    if(mkdir.sync(directoryPath)){
+      logger.success(`+ ${directoryPath}`);
+    }
+    else {
+      logger.error(`! ${directoryPath} already exists.`);
+    }
+  }
+
+}

--- a/src/project-creation/file-creator.js
+++ b/src/project-creation/file-creator.js
@@ -1,0 +1,9 @@
+import filesystem from 'fs';
+
+export default {
+
+  run(path, contents) {
+    filesystem.writeFileSync(path, contents);
+  }
+
+}

--- a/src/project-creation/gitignore-creator.js
+++ b/src/project-creation/gitignore-creator.js
@@ -1,0 +1,20 @@
+import logger from '../util/logger';
+import FileCreator from './file-creator';
+
+export default {
+
+  buildTemplate(name){
+    return `node_modules
+`;
+  },
+
+  run(directoryPath, name) {
+    const template = this.buildTemplate(name)
+    const path = `${directoryPath}/.gitignore`;
+
+    FileCreator.run(path, template);
+
+    logger.success(`+ ${path}`);
+  }
+
+}

--- a/src/project-creation/package-creator.js
+++ b/src/project-creation/package-creator.js
@@ -1,0 +1,34 @@
+import logger from '../util/logger';
+import FileCreator from './file-creator';
+
+export default {
+
+  buildTemplate(name){
+    return `{
+  "name": "blackjack-${name}",
+  "version": "0.0.1",
+  "description": "A blackjack component.",
+  "scripts": {
+    "test": "blackjack test"
+  },
+  "author": "Sky UK",
+  "license": "\tBSD-3-Clause",
+  "dependencies": {
+    "babel-loader": "^6.2.4",
+    "react": "^0.14.8",
+    "sky-toolkit": "github:sky-uk/toolkit"
+  }
+}
+`;
+  },
+
+  run(directoryPath, name) {
+    const template = this.buildTemplate(name)
+    const path = `${directoryPath}/package.json`;
+
+    FileCreator.run(path, template);
+
+    logger.success(`+ ${path}`);
+  }
+
+}

--- a/src/project-creation/readme-creator.js
+++ b/src/project-creation/readme-creator.js
@@ -1,0 +1,25 @@
+import caseChanger from 'change-case';
+import logger from '../util/logger';
+import FileCreator from './file-creator';
+
+export default {
+
+  buildTemplate(name){
+    const title = caseChanger.titleCase(name);
+
+    return `# ${title} Blackjack Component
+
+A readme for your component would go here.
+`;
+  },
+
+  run(directoryPath, name) {
+    const template = this.buildTemplate(name)
+    const path = `${directoryPath}/readme.md`;
+
+    FileCreator.run(path, template);
+
+    logger.success(`+ ${path}`);
+  }
+
+}

--- a/src/project-creation/styles-creator.js
+++ b/src/project-creation/styles-creator.js
@@ -1,0 +1,25 @@
+import caseChanger from 'change-case';
+import logger from '../util/logger';
+import DirectoryCreator from './directory-creator';
+import FileCreator from './file-creator';
+
+export default {
+
+  buildTemplate(name){
+    return `.${name} {}
+`;
+  },
+
+  run(directoryPath, name) {
+    const directory = `${directoryPath}/styles`;
+    const underscoreName = caseChanger.snakeCase(name);
+    const template = this.buildTemplate(name)
+    const path = `${directory}/${underscoreName}.js`;
+
+    DirectoryCreator.run(directory)
+    FileCreator.run(path, template);
+
+    logger.success(`+ ${path}`);
+  }
+
+}

--- a/src/project-creation/test-creator.js
+++ b/src/project-creation/test-creator.js
@@ -1,0 +1,34 @@
+import caseChanger from 'change-case';
+import logger from '../util/logger';
+import DirectoryCreator from './directory-creator';
+import FileCreator from './file-creator';
+
+export default {
+
+  buildTemplate(name){
+    const klass = caseChanger.pascalCase(name);
+    const path = caseChanger.snakeCase(name);
+
+    return `import ${klass} from '../../src/components/${path}';
+
+describe('${klass}', () => {
+
+  it('should render', () => {});
+
+});
+`;
+  },
+
+  run(directoryPath, name) {
+    const directory = `${directoryPath}/test/components`;
+    const underscoreName = caseChanger.snakeCase(name);
+    const template = this.buildTemplate(name)
+    const path = `${directory}/${underscoreName}.test.js`;
+
+    DirectoryCreator.run(directory)
+    FileCreator.run(path, template);
+
+    logger.success(`+ ${path}`);
+  }
+
+}

--- a/src/util/exec.js
+++ b/src/util/exec.js
@@ -1,13 +1,16 @@
 import { exec } from 'child_process';
+import logger from './logger';
 
 export default function(command) {
   exec(command + ' --color', (error, stdout, stderr) => {
-    console.log(`${stdout}`);
+    logger.info(`${stdout}`);
+
     if(stderr) {
-      console.log(`${stderr}`);
+      logger.info(`${stderr}`);
     }
+
     if (error !== null) {
-      console.log(`exec error: ${error}`);
+      logger.error(`exec error: ${error}`);
     }
   });
 }

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,0 +1,25 @@
+const colors = require('colors/safe');
+
+function log(color, message){
+  console.log(colors[color](message));
+}
+
+export default {
+
+  info(message){
+    log('white', message);
+  },
+
+  warn(message){
+    log('yellow', message);
+  },
+
+  error(message){
+    log('red', message);
+  },
+
+  success(message){
+    log('green', message);
+  }
+
+}


### PR DESCRIPTION
This PR implements a complete `init` command, setting up a directory structure ready for component development. Usage is as follows:

```bash
blackjack init MyNewComponent
blackjack init my-new-component
blackjack init my_new_component
```

It doesn't matter what format you type the name in, the application with normalise it.

Example output:

![Example](http://wearest.ac/162nu+)

Example project structure (download [here](http://wearest.ac/1lBgQ)):

```
my-new-component
├── package.json
├── readme.md
├── src
│   └── components
│       └── my_new_component.js
├── styles
│   └── my_new_component.js
└── test
    └── components
        └── my_new_component.test.js

5 directories, 5 files
```

This is just a starting point, the idea being that we're going to create many more components over the next few months, so we may as well agree a starting point.