### PR TITLE
Fix module lookup paths in Karma and Mocha to make for more concise requires

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -17,7 +17,7 @@ export function call(options) {
   switch(runner){
 
     case 'mocha':
-      exec(`${MOCHA_BIN} "${TEST_GLOB}" --require ${BLACKJACK_HOME}/src/vendor-integration/mocha/environment.js --harmony --es_staging`);
+      exec(`${ENV_VARS} ${MOCHA_BIN} "${TEST_GLOB}" --require ${BLACKJACK_HOME}/src/vendor-integration/mocha/environment.js --harmony --es_staging`);
     break;
 
     case 'karma':

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -4,9 +4,12 @@ import {
   MOCHA_BIN,
   TEST_GLOB,
   BLACKJACK_HOME,
+  WORKING_DIR,
   KARMA_CONF,
   KARMA_BIN
 } from '../constants';
+
+const ENV_VARS = `BLACKJACK_HOME=${BLACKJACK_HOME} WORKING_DIR=${WORKING_DIR}`
 
 export function call(options) {
   const runner = options.runner || 'mocha';
@@ -18,7 +21,7 @@ export function call(options) {
     break;
 
     case 'karma':
-      exec(`${KARMA_BIN} start ${KARMA_CONF}`);
+      exec(`${ENV_VARS} ${KARMA_BIN} start ${KARMA_CONF}`);
     break;
 
     default:

--- a/src/vendor-integration/karma/config.js
+++ b/src/vendor-integration/karma/config.js
@@ -1,8 +1,6 @@
 const path = require("path");
-const consts = require('../../constants');
-
-const WORKING_DIR = consts.WORKING_DIR;
-const BLACKJACK_HOME = consts.BLACKJACK_HOME;
+const BLACKJACK_HOME = process.env.BLACKJACK_HOME;
+const WORKING_DIR = process.env.WORKING_DIR;
 
 module.exports = function(config) {
   var karmaConf = {
@@ -43,7 +41,8 @@ module.exports = function(config) {
         resolve: {
           root: [
             path.join(BLACKJACK_HOME, 'node_modules'),
-            path.join(WORKING_DIR, 'node_modules')
+            path.join(WORKING_DIR, 'node_modules'),
+            path.join(WORKING_DIR, 'src')
           ]
         },
     },

--- a/src/vendor-integration/mocha/environment.js
+++ b/src/vendor-integration/mocha/environment.js
@@ -1,8 +1,6 @@
+const BLACKJACK_HOME = process.env.BLACKJACK_HOME;
+const WORKING_DIR = process.env.WORKING_DIR;
 const paths = require('app-module-path');
-const constants = require('constants');
-
-const BLACKJACK_HOME = constants.BLACKJACK_HOME;
-const WORKING_DIR = constants.WORKING_DIR;
 
 require("babel-register")({
   sourceMaps: 'inline',
@@ -13,12 +11,8 @@ require("babel-register")({
   ]
 });
 
-module.exports = {
-
-  setup(){
-    paths.addPath(`${BLACKJACK_HOME}/node_modules`);
-    paths.addPath(`${WORKING_DIR}/node_modules`);
-    paths.addPath(`${WORKING_DIR}/src`);
-  }
-
-}
+module.exports = function(){
+  paths.addPath(`${BLACKJACK_HOME}/node_modules`);
+  paths.addPath(`${WORKING_DIR}/node_modules`);
+  paths.addPath(`${WORKING_DIR}/src`);
+}()


### PR DESCRIPTION
As requested by @mackstar in sky-uk/blackjack-accordion#1, this ensures that modules are correctly looked up relative to the component project.